### PR TITLE
Add on fail function parameter

### DIFF
--- a/cjs/app/index.d.ts
+++ b/cjs/app/index.d.ts
@@ -56,6 +56,7 @@ type AppOptions = {
     disableStringDict?: boolean;
     onStart?: StartCallback;
     network?: NetworkOptions;
+    callOnFailureFunc?: () => void;
 } & WebworkerOptions & SessOptions;
 export type Options = AppOptions & ObserverOptions & SanitizerOptions;
 export declare const DEFAULT_INGEST_POINT = "https://api.openreplay.com/ingest";

--- a/cjs/app/index.js
+++ b/cjs/app/index.js
@@ -69,6 +69,7 @@ class App {
             sessionStorage: null,
             disableStringDict: false,
             forceSingleTab: false,
+            callOnFailureFunc: undefined,
         }, options);
         if (!this.options.forceSingleTab && globalThis && 'BroadcastChannel' in globalThis) {
             this.bc = (0, utils_js_1.inIframe)() ? null : new BroadcastChannel('rick');
@@ -579,6 +580,9 @@ class App {
             }
             finally {
                 this.activityState = ActivityState.NotActive;
+                if (this.options.callOnFailureFunc) {
+                    this.options.callOnFailureFunc();
+                }
             }
         }
     }

--- a/cjs/index.d.ts
+++ b/cjs/index.d.ts
@@ -27,6 +27,7 @@ export type Options = Partial<AppOptions & ConsoleOptions & ExceptionOptions & I
         onFlagsLoad?: (flags: IFeatureFlag[]) => void;
     };
     __DISABLE_SECURE_MODE?: boolean;
+    callOnFailureFunc?: () => void;
 };
 export default class API {
     private readonly options;

--- a/lib/app/index.d.ts
+++ b/lib/app/index.d.ts
@@ -56,6 +56,7 @@ type AppOptions = {
     disableStringDict?: boolean;
     onStart?: StartCallback;
     network?: NetworkOptions;
+    callOnFailureFunc?: () => void;
 } & WebworkerOptions & SessOptions;
 export type Options = AppOptions & ObserverOptions & SanitizerOptions;
 export declare const DEFAULT_INGEST_POINT = "https://api.openreplay.com/ingest";

--- a/lib/app/index.js
+++ b/lib/app/index.js
@@ -66,6 +66,7 @@ export default class App {
             sessionStorage: null,
             disableStringDict: false,
             forceSingleTab: false,
+            callOnFailureFunc: undefined,
         }, options);
         if (!this.options.forceSingleTab && globalThis && 'BroadcastChannel' in globalThis) {
             this.bc = inIframe() ? null : new BroadcastChannel('rick');
@@ -576,6 +577,9 @@ export default class App {
             }
             finally {
                 this.activityState = ActivityState.NotActive;
+                if (this.options.callOnFailureFunc) {
+                    this.options.callOnFailureFunc();
+                }
             }
         }
     }

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -27,6 +27,7 @@ export type Options = Partial<AppOptions & ConsoleOptions & ExceptionOptions & I
         onFlagsLoad?: (flags: IFeatureFlag[]) => void;
     };
     __DISABLE_SECURE_MODE?: boolean;
+    callOnFailureFunc?: () => void;
 };
 export default class API {
     private readonly options;

--- a/src/main/app/index.ts
+++ b/src/main/app/index.ts
@@ -90,6 +90,7 @@ type AppOptions = {
   // @deprecated
   onStart?: StartCallback
   network?: NetworkOptions
+  callOnFailureFunc?: () => void
 } & WebworkerOptions &
   SessOptions
 
@@ -161,6 +162,7 @@ export default class App {
         sessionStorage: null,
         disableStringDict: false,
         forceSingleTab: false,
+        callOnFailureFunc: undefined,
       },
       options,
     )
@@ -757,6 +759,9 @@ export default class App {
         }
       } finally {
         this.activityState = ActivityState.NotActive
+        if (this.options.callOnFailureFunc) {
+          this.options.callOnFailureFunc()
+        }
       }
     }
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -59,6 +59,7 @@ export type Options = Partial<
   }
   // dev only
   __DISABLE_SECURE_MODE?: boolean
+  callOnFailureFunc?: () => void
 }
 
 const DOCS_SETUP = '/installation/javascript-sdk'


### PR DESCRIPTION
This PR adds the option to pass a function to the tracker constructor as "callOnFailureFunc". This function will be called by openReplay in the case it fails.

The purpose of this is to allow the Aven frontend to pass in a function that will handle the failure of openReplay. More specifically, this change was introduced to allow the frontend to reinitialize openReplay in the case of a failure due to a temporary network outage. See this PR: [https://github.com/heraclescorp/heracles/pull/47245](https://github.com/heraclescorp/heracles/pull/47245)